### PR TITLE
Add issue template for bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: 🐞 Bug Report
+description: Report broken or incorrect functionality
+title: "[Bug] "
+labels: ["bug", "needs-verification"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ⚠️ **Bug reports are only for broken functionality.**
+        For feature requests or enhancements, please use the appropriate template.
+
+        🚫 Do **NOT** include personal or sensitive information in logs, screenshots, code, etc.
+
+  - type: textarea
+    attributes:
+      label: Bug Summary
+      description: Provide a clear and concise summary of the bug, expected behavior, screenshots, and logs.
+      placeholder: The application crashes when I ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 🔁 Steps to Reproduce
+      description: Provide the exact steps to reproduce the issue.
+      placeholder: |
+        1. Open the app
+        2. Click on "X"
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 🔍 Minimal Reproducible Example
+      description: Provide the smallest, self-contained code snippet that reliably reproduces the issue.
+      render: python
+      placeholder: |
+        import pydanticInput, import pydantic
+        class MyModel(pydantic.BaseModel): ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Buggy Version Information
+      description: The version of OS, application and relevant libraries. Run `pydanticInput --debug` to get this info.
+      placeholder: |
+        OS: Linux 6.1.0-35-amd64 (Debian 6.1.137-1)
+        Architecture: x86_64
+        Python version: 3.10.18
+        App version: 0.1.0
+        Dependencies:
+        * pydantic: 2.11.7
+        * pyside6-essentials: 6.9.1
+
+        **last working version**
+        ...
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: 🐞 Bug Severity (Impact Rating)
+      description: How badly does this bug affect your work?
+      options:
+        - 🔹 Minor – It's annoying but doesn't block me
+        - ⚠️ Moderate – I can work around it, but it's inconvenient
+        - 🚫 Critical – Blocks my work or breaks a major feature
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 💬 Additional Context
+      description: Add any extra context, ideas, or known workarounds.
+      placeholder: Anything else we should know?
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Misc
+      options:
+        - label: This bug can be reliably reproduced
+          required: true
+        - label: I have searched existing issues for similar bugs
+          required: true
+        - label: I am willing to contribute a fix if possible

--- a/pydanticInput/main.py
+++ b/pydanticInput/main.py
@@ -1,3 +1,9 @@
+import argparse
+import platform
+import re
+from importlib import metadata
+from pathlib import Path
+
 import pydantic
 from PySide6.QtWidgets import QApplication, QDialogButtonBox, QScrollArea
 
@@ -36,3 +42,82 @@ def Input(model: type[pydantic.BaseModel]) -> dict:
     scroll_area.show()
     app.exec()
     return vals
+
+
+def get_dependency_versions(package: str = "pydanticInput") -> dict:
+    """
+    Retrieves the installed versions of dependencies for a specified Python
+    package. This function reads the package's METADATA file to extract its
+    dependencies, then attempts to determine the installed version of each
+    dependency.
+
+    Args:
+        package (str): The name of the package whose dependencies' versions are
+        to be retrieved.
+        * Defaults to "pydanticInput".
+
+    Returns:
+        dict: A dictionary mapping dependency names to their installed versions.
+            * If a dependency is not installed, value will be "not installed"
+            * If the METADATA file is not found, returns an empty dictionary.
+    """
+
+    versions = {}
+    # Find METADATA for the current package
+    metadata_file = Path(metadata.distribution(package)._path, "METADATA")
+    if not metadata_file.is_file():
+        return versions
+    for match in re.finditer(
+        r"^Requires-Dist: (.+)", metadata_file.read_text(encoding="utf-8"), re.M
+    ):
+        dep = re.split(r"[<>=]", match.group(1))[0].strip()
+        try:
+            versions[dep] = metadata.version(dep)
+        except metadata.PackageNotFoundError:
+            versions[dep] = "not installed"
+    return versions
+
+
+def debug_info() -> str:
+    """
+    Collects and returns a formatted string containing debug information about
+    the current environment. The returned string includes:
+        - Operating system name, release, and version
+        - System architecture
+        - Python version
+        - Application version (from pydanticInput.__version__)
+        - A list of dependencies and their versions
+
+    Returns:
+        str: A multi-line string with environment and dependency information.
+    """
+
+    info = (
+        f"OS: {platform.system()} {platform.release()} ({platform.version()})\n"
+        f"Architecture: {platform.machine()}\n"
+        f"Python version: {platform.python_version()}\n"
+        f"App version: {pydanticInput.__version__}\n"
+        "Dependencies:\n"
+    )
+    for dep, ver in get_dependency_versions().items():
+        info += f"* {dep}: {ver}\n"
+    return info
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="pydanticInput CLI")
+    parser.add_argument(
+        "--version", action="store_true", help="show version information"
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="show debug information"
+    )
+    args = parser.parse_args()
+    if args.version:
+        print(pydanticInput.__version__)
+    elif args.debug:
+        print(debug_info())
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic>=2.11.7",
     "pyside6-essentials>=6.9.1",
 ]
+scripts.pydanticInput = "pydanticInput.main:main"
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,6 @@ wheels = [
 
 [[package]]
 name = "pydanticinput"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Issue template for bug report is added for gathering structured and useful information for a bug report
Add the `--version` cli option to print the version
Add the `--debug` cli option to print useful debug info like OS, architecture, python version, application version, and versions of app dependencies. 