### PR TITLE
Drop the Test PyPI publish stage

### DIFF
--- a/.github/workflows/publish_dist.yml
+++ b/.github/workflows/publish_dist.yml
@@ -14,38 +14,6 @@ jobs:
   testing:
     uses: ./.github/workflows/code_test.yml
 
-  publish-test-pypi:
-    runs-on: ubuntu-latest
-
-    environment:
-      name: test-pypi
-
-    needs: testing
-
-    steps:
-
-      - &download_dist
-        name: Download Distributions
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ needs.testing.outputs.artifact_name }}
-          run-id: ${{ needs.testing.outputs.artifact_run_id }}
-          path: ./dist
-
-      - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          verbose: true
-
-      - name: Smoke Test on Test PyPI
-        shell: bash
-        run: |
-          sleep 60
-          pip install -v --index-url https://test.pypi.org/simple/ \
-          --extra-index-url https://pypi.org/simple/ brayer
-          python -c "import brayer;print(brayer.__version__)"
-
   publish-to-pypi:
     runs-on: ubuntu-latest
 
@@ -56,7 +24,13 @@ jobs:
 
     steps:
 
-      - *download_dist
+      - name: Download Distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.testing.outputs.artifact_name }}
+          run-id: ${{ needs.testing.outputs.artifact_run_id }}
+          path: ./dist
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
## Summary

Removes the `publish-test-pypi` job from `publish_dist.yml`. A published release now runs the test matrix and goes straight to PyPI.

The release pipeline goes from `testing → publish-test-pypi → publish-to-pypi → publish_docs` to `testing → publish-to-pypi → publish_docs`, cutting the ~60s Test PyPI smoke-test wait and its propagation delay off every release.

## One thing worth noting

`Download Distributions` is now written out inline in `publish-to-pypi`. It had been a YAML anchor (`&download_dist`) *defined inside* the job being deleted and aliased (`*download_dist`) from `publish-to-pypi`, so deleting the job outright would have left a dangling alias and broken the workflow parse. The step's content is unchanged.

## Test plan

- YAML parses; jobs are now `testing`, `publish-to-pypi`, `publish_docs`.
- `publish-to-pypi` steps resolve to `Download Distributions`, `Publish to PyPI`, `Smoke Test on PyPI`, with the artifact `name`/`run-id`/`path` inputs identical to before.
- `publish_docs` still gates on `publish-to-pypi`.
- No references to Test PyPI remain anywhere in the repo.
- This workflow is `release`-triggered only, so PR checks cannot exercise it — it runs for real on the next published release.

## Follow-up (needs repo settings, not a code change)

The `test-pypi` GitHub **environment** is now unused. It's harmless to leave, but you may want to delete it in Settings → Environments, along with any trusted-publisher entry for this repo on test.pypi.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)