### PR TITLE
Install Qt runtime libraries before the PyPI smoke test

### DIFF
--- a/.github/workflows/publish_dist.yml
+++ b/.github/workflows/publish_dist.yml
@@ -36,9 +36,24 @@ jobs:
         with:
           verbose: true
 
+      # brayer imports PySide6 at package import time, so the smoke test
+      # needs the same Qt runtime libraries the test matrix installs --
+      # see the matching step in code_test.yml. Without them the import
+      # dies on "libEGL.so.1: cannot open shared object file", which
+      # looks like a broken release rather than a bare runner.
+      - name: Install Qt runtime libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends             libegl1             libgl1             libdbus-1-3             libxkbcommon-x11-0             libxcb-cursor0             libxcb-icccm4             libxcb-image0             libxcb-keysyms1             libxcb-randr0             libxcb-render-util0             libxcb-shape0             libxcb-xinerama0             libxcb-xkb1
+
       - name: Smoke Test on PyPI
         shell: bash
+        env:
+          # No display on the runner; render into memory instead.
+          QT_QPA_PLATFORM: offscreen
+          QT_LOGGING_RULES: "qt.qpa.*=false"
         run: |
+          # PyPI's index can lag the upload by a few seconds.
           sleep 60
           pip install -v --index-url https://pypi.org/simple/ brayer
           python -c "import brayer;print(brayer.__version__)"


### PR DESCRIPTION
## Summary

The `v0.1.0` release job failed at its final step:

```
ImportError: libEGL.so.1: cannot open shared object file: No such file or directory
  File ".../brayer/handlers/pydantic_types.py", line 19, in <module>
    from PySide6 import QtWidgets
```

**The release itself was fine.** The upload returned `200 OK` and [brayer 0.1.0](https://pypi.org/project/brayer/0.1.0/) is live and installable. What broke is the post-publish smoke test: `brayer` imports PySide6 at package import time, and the `publish-to-pypi` job runs on a bare `ubuntu-latest` with no Qt runtime libraries and no display. A red release job here reads as a broken package when it is really a missing system library.

`code_test.yml` already solved this — it has an `Install Qt runtime libraries` step and sets `QT_QPA_PLATFORM=offscreen` at the workflow level. The publish job never got either. This ports both across.

## Test plan

- The package list is identical to the one in `code_test.yml`, which passes `import PySide6.QtWidgets` on Linux across the whole 3.10–3.14 matrix, including a dedicated `Verify Qt imports headlessly` step.
- Workflow parses; `publish-to-pypi` steps are now `Download Distributions`, `Publish to PyPI`, `Install Qt runtime libraries`, `Smoke Test on PyPI`, with the Qt env vars scoped to the smoke test.
- **Not verified by direct reproduction:** this is `release`-triggered only, so PR checks cannot exercise it, and Docker was unavailable locally to reproduce the bare-runner import. The evidence is parity with the passing test matrix, not a local run. It executes for real on the next published release.

## Note

`libegl1` alone would clear the reported error, but the full list is used deliberately: it matches `code_test.yml` exactly, so the two stay in step and the smoke test cannot pass while the matrix fails on some other missing `.so`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)